### PR TITLE
Issue 928 - Simplify JavaScript in the Zest theme

### DIFF
--- a/partials/shop-checkout-address.htm
+++ b/partials/shop-checkout-address.htm
@@ -53,7 +53,7 @@
             The state selector updates automatically when the country changes. 
             See app.js for the implementation details. 
           -->        
-          <select id="billing_country" name="billingInfo[countryId]" data-state-select="billing_state" data-current-state="{{ billingInfo.stateId }}">
+          <select id="billing_country" name="billingInfo[countryId]" data-state-selector="#billing_state" data-current-state="{{ billingInfo.stateId }}">
             {% for country in countries %}
               <option {{ option_state(billingInfo.countryId, country.id) }} value="{{ country.id }}">{{ country.name }}</option>
             {% endfor %}
@@ -62,7 +62,7 @@
         </div>
         <div class="six columns">
           <label for="billing_state">State</label>
-          <select id="billing_state" name="billingInfo[stateId]"> 
+          <select id="billing_state" name="billingInfo[stateId]" data-ajax-refresh > 
             {{ partial('shop-stateoptions', {'states': billingStates, 'selected': billingInfo.stateId}) }}
           </select>
           <span class="error"></span>
@@ -114,7 +114,7 @@
       <div class="row">
         <div class="six columns">
           <label for="shipping_country">Country</label>
-          <select id="shipping_country" name="shippingInfo[countryId]" data-state-select="shipping_state" data-current-state="{{ shippingInfo.stateId }}">
+          <select id="shipping_country" name="shippingInfo[countryId]" data-state-selector="#shipping_state" data-current-state="{{ shippingInfo.stateId }}" >
             {% for country in countries %}
               <option {{ option_state(shippingInfo.countryId, country.id) }} value="{{ country.id }}">{{ country.name }}</option>
             {% endfor %}
@@ -123,7 +123,7 @@
         </div>
         <div class="six columns">
           <label for="shipping_state">State</label>
-          <select id="shipping_state" name="shippingInfo[stateId]"> 
+          <select id="shipping_state" name="shippingInfo[stateId]" data-ajax-refresh > 
             {{ partial('shop-stateoptions', {'states': shippingStates, 'selected': shippingInfo.stateId}) }}
           </select>
           <span class="error"></span>

--- a/partials/shop-customerprofile.htm
+++ b/partials/shop-customerprofile.htm
@@ -52,7 +52,7 @@
             The state selector updates automatically when the country changes. 
             See app.js for the implementation details. 
           -->        
-          <select id="billing_country" name="billing[shop_country_id]" data-state-select="billing_state" data-current-state="{{ billing.country.id }}">
+          <select id="billing_country" name="billing[shop_country_id]" data-state-selector="#billing_state" data-current-state="{{ billing.country.id }}">
             {% for country in countries %}
               <option {{ option_state(billing.country.id, country.id) }} value="{{ country.id }}">{{ country.name }}</option>
             {% endfor %}
@@ -61,7 +61,7 @@
         </div>
         <div class="six columns">
           <label for="billing_state">State</label>
-          <select id="billing_state" name="billing[shop_state_id]"> 
+          <select id="billing_state" name="billing[shop_state_id]" data-ajax-refresh > 
             {{ partial('shop-stateoptions', {'states': billingStates, 'selected': billing.state.id}) }}
           </select>
           <span class="error"></span>
@@ -117,7 +117,7 @@
       <div class="row">
         <div class="six columns">
           <label for="shipping_country">Country</label>
-          <select id="shipping_country" name="shipping[shop_country_id]" data-state-select="shipping_state" data-current-state="{{ shipping.country.id }}">
+          <select id="shipping_country" name="shipping[shop_country_id]" data-state-selector="#shipping_state" data-current-state="{{ shipping.country.id }}">
             {% for country in countries %}
               <option {{ option_state(shipping.country.id, country.id) }} value="{{ country.id }}">{{ country.name }}</option>
             {% endfor %}
@@ -126,7 +126,7 @@
         </div>
         <div class="six columns">
           <label for="shipping_state">State</label>
-          <select id="shipping_state" name="shipping[shop_state_id]"> 
+          <select id="shipping_state" name="shipping[shop_state_id]" data-ajax-refresh> 
             {{ partial('shop-stateoptions', {'states': shippingStates, 'selected': shipping.state.id}) }}
           </select>
           <span class="error"></span>

--- a/partials/shop-product-options.htm
+++ b/partials/shop-product-options.htm
@@ -3,7 +3,7 @@
     {% for index, option in product.options %}
       <div class="option">
         <label class="title" for="{{ 'option-'~index }}">{{ option.name }}</label>
-        <select id="{{ 'option-'~index }}" name="options[{{ option.id }}]" class="product-option">
+        <select id="{{ 'option-'~index }}" name="options[{{ option.id }}]" class="product-option" data-ajax-handler="shop:product" data-ajax-update="#product-page=shop-product">
           {% for key, value in option.values %}
             <option value='{{ key }}' {{ option_state(postedOptions[option.id], key) }}>{{ value }}</option>
           {% endfor %}

--- a/resources/javascript/app.js
+++ b/resources/javascript/app.js
@@ -50,6 +50,7 @@
   //
   $(window).on('onAfterAjaxUpdate', function(){
     $(document).foundationCustomForms();
+    $("select[data-ajax-refresh]").change() // Forces Foundation to redraw the drop-down for states select elements after update
   });
 
   $(document).ready(function() {
@@ -61,13 +62,6 @@
 
       return false;
     })
-
-    //Handle selecting product option
-    $(document).on('change', 'select.product-option', function () {
-      $(this).sendRequest('shop:product', {
-          update: {'#product-page': 'shop-product'}
-      });
-    });
 
     //
     // Handle the Enter key in the Coupon field
@@ -136,27 +130,6 @@
           }
       });
     })
-
-    // 
-    // Automatically update state lists when a country is changed
-    //
-    $(document).on('change', '[data-state-select]', function(){
-      var 
-        stateSelectorId = $(this).data('state-select');
-        updateList = {};
-        
-      updateList['#'+stateSelectorId] = 'shop-stateoptions';
-
-      $(this).sendRequest('shop:onUpdateStateList', {
-          extraFields: {
-            country_id: $(this).val(),
-            state_id: $(this).data('current-state')
-          },
-          update: updateList,
-          onAfterUpdate: function() {
-            $('#'+stateSelectorId).change(); // Forces Foundation to redraw the drop-down element
-          }
-      });
-    });
+    
   });
 })(jQuery);


### PR DESCRIPTION
- Removed states dropdown handler from app.js, using core.js functionality instead. Added data attributes to state select in shop-checkout-address and shop-customerprofile.
- Removed product options handler form app.js and replaced it with ajax attributes in shop-product-options.
