### PR TITLE
Discount updates, enable coupon code field, fix shipping method step

### DIFF
--- a/partials/shop-cart-content.htm
+++ b/partials/shop-cart-content.htm
@@ -37,17 +37,20 @@
         </div>
       </div>
       
-      <a class="button" href="#" data-ajax-handler="shop:on_evalShippingRate" data-ajax-update="#shipping_options=shopestimatedshippingoptions">Calculate</a>
+      <a class="button" href="#" data-ajax-handler="shop:onEvalShippingRate" data-ajax-update="#shipping_options=shopestimatedshippingoptions">Calculate</a>
         
       <div id="shipping_options"></div>
     </div>
     
     <div class="three columns offset-by-three data-list align-right">
-      {% if cart.getDiscountTotal() > 0 %}
-        <p><strong>Discount applied:</strong> <i>{{ cart.getDiscountTotal()|currency }}</i></p>
+      {% if totals.discountTotal > 0 %}
+        <p><strong>Coupon discount:</strong> <i>{{ totals.discountTotal|currency }}</i></p>
       {% endif %}
-      <p><strong>Cart total:</strong> <i>{{ cart.getSubtotal()|currency }}</i></p>
-      <p class="subtotal"><strong>Estimated total:</strong>  <i>{{ cart.getTotal()|currency }}</i></p>
+      <p><strong>Cart total:</strong> <i>{{ totals.subtotal|currency }}</i></p>
+      {% if totals.totalShippingQuote > 0 %}
+        <p><strong>Shipping:</strong> <i>{{ totals.totalShippingQuote|currency }}</i></p>
+      {% endif %}
+      <p class="subtotal"><strong>Estimated total:</strong>  <i>{{ totals.total|currency }}</i></p>
     </div>
   </div>  
   <div class="row">
@@ -57,7 +60,7 @@
       </div>
       <div class="six columns">
         <div class="right">
-          <input type="text" id="coupon" name="coupon" value="{{ coupon_code }}" placeholder="Coupon code" disabled />
+          <input type="text" id="coupon" name="coupon" value="{{ coupon_code }}" placeholder="Coupon code" />
         
           <a class="secondary button" href="#" data-ajax-handler="shop:cart" data-ajax-update="#cart-content=shop-cart-content, #mini-cart=shop-minicart">Update cart</a>
           {% if customer %}

--- a/partials/shop-checkout-shippingmethod.htm
+++ b/partials/shop-checkout-shippingmethod.htm
@@ -14,7 +14,7 @@
                   <input name="shippingMethod" 
                     {{ option.error_hint ? 'disabled' : null }} 
                     value="{{ index }}" 
-                    {{ radio_state(option.shippingMethodId, shippingMethod) }}
+                    {{ radio_state(shippingMethodInfo.id, option.id) }}
                     type="radio" id="{{ 'option'~index }}"/>
                     
                   <span class="choice-title">

--- a/partials/shop-checkout-totals.htm
+++ b/partials/shop-checkout-totals.htm
@@ -1,9 +1,9 @@
-{% if discount %}
-  <p><strong>Discount applied:</strong> <i>{{ discount|currency }}</i></p>
+{% if totals.discountTotal > 0 %}
+  <p><strong>Discount applied:</strong> <i>{{ totals.discountTotal|currency }}</i></p>
 {% endif %}
-<p><strong>Cart total:</strong> <i>{{ totals.subtotalNoTax|currency }}</i></p>
+<p><strong>Cart total:</strong> <i>{{ totals.subtotal|currency }}</i></p>
 {% if totals.totalShippingQuote %}
   <p><strong>Shipping:</strong> <i>{{ totals.totalShippingQuote|currency }}</i></p>
 {% endif %}
 <p><strong>Tax:</strong> <i>{{ totals.totalTax|currency }}</i></p>
-<p class="subtotal"><strong>Total:</strong>  <i>{{ totals.total|currency }}</i></p>  
+<p class="subtotal"><strong>Total:</strong>  <i>{{ totals.total|currency }}</i></p>

--- a/partials/shop-invoicetotals.htm
+++ b/partials/shop-invoicetotals.htm
@@ -4,7 +4,7 @@
 <p><strong>Subtotal:</strong> <i>{{ invoice.subtotal|currency }}</i></p>
 <p><strong>Sales Tax:</strong> <i>{{ invoice.tax_total|currency }}</i></p>
 <p><strong>Shipping:</strong> <i>{{ invoice.total_shipping_quote|currency }}</i></p>
-{% if invoice.shipping_tax %}
-  <p><strong>Shipping Taxes:</strong> <i>{{ order.shipping_tax|currency }}</i></p>
+{% if invoice.order.total_shipping_tax > 0 %}
+  <p><strong>Shipping Taxes:</strong> <i>{{ invoice.order.total_shipping_tax|currency }}</i></p>
 {% endif %}
 <p class="subtotal"><strong>Total:</strong>  <i>{{ invoice.total|currency }}</i></p>

--- a/partials/shop-ordertotals.htm
+++ b/partials/shop-ordertotals.htm
@@ -1,4 +1,6 @@
-<p><strong>Discount applied:</strong> <i>{{ 0|currency }}</i></p>
+{% if order.total_discount %}
+  <p><strong>Discount applied:</strong> <i>{{ order.total_discount|currency }}</i></p>
+{% endif %}
 <p><strong>Subtotal:</strong> <i>{{ order.subtotal_invoiced|currency }}</i></p>
 <p><strong>Sales Tax:</strong> <i>{{ order.total_sales_tax|currency }}</i></p>
 <p><strong>Shipping:</strong> <i>{{ order.total_shipping_quote|currency }}</i></p>


### PR DESCRIPTION
Enabled the coupon code field on the cart page and included discount values where applicable.

Applies the lemonstand/lemonstand-2#1203 fix for the Zest theme.
